### PR TITLE
feat: concurrently added

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,12 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/react-redux": "^7.1.11",
-    "@types/rebass": "^4.0.7"
+    "@types/rebass": "^4.0.7",
+    "concurrently": "^5.3.0"
   },
   "scripts": {
-    "server": "npx json-server --watch db.json",
+    "serve": "concurrently  \"npm run server\" \"PORT=5000 npm run start\"",
+    "server": "npx json-server --watch --port=3000 db.json",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",


### PR DESCRIPTION
By running `npm run serve` the react app will be exposed to the port 5000
and the json mock server to the port 3000